### PR TITLE
upgrade react-tap-event-plugin to v2.0.0 to resolve react 15.4.0 upgrade issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "electrode-redux-router-engine": "^1.2.2",
     "electrode-server": "^1.1.1",
     "electrode-static-paths": "^1.0.0",
-    "material-ui": "^0.15.4",
-    "react": "^15.3.2",
-    "react-dom": "^15.3.2",
+    "material-ui": "^0.16.2",
+    "react": "^15.4.0",
+    "react-dom": "^15.4.0",
     "react-tap-event-plugin": "^2.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "material-ui": "^0.15.4",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-tap-event-plugin": "^1.0.0"
+    "react-tap-event-plugin": "^2.0.0"
   },
   "dependencies": {
     "ansi-to-html": "^0.4.1",


### PR DESCRIPTION
reference issue:

https://github.com/zilverline/react-tap-event-plugin/issues/85