### PR TITLE
[Bugfix] Ensure "ignored" modules don't break output

### DIFF
--- a/lib/module-processor.js
+++ b/lib/module-processor.js
@@ -88,6 +88,11 @@ class ModuleProcessor {
     const byPkg = this.modulesByPackage = {};
     this.totalSize = 0;
     Object.keys(this.modulesByName).forEach((name) => {
+      // Ignore "ignored" modules i.e. node shims etc.
+      if (name.indexOf('(ignored)') > -1) {
+        return;
+      }
+
       const split = this._splitPathName(name);
       const pkg = byPkg[split.name] || (byPkg[split.name] = {size: 0});
       const getVersion = (parents) => {


### PR DESCRIPTION
Currently the reporter borks when it encounters an "ignored" module, such as node shims. This fixes the issue by simply omitting them all together