### PR TITLE
[Bugfix] Add missing jsonData variable

### DIFF
--- a/lib/webpack-reporter.js
+++ b/lib/webpack-reporter.js
@@ -56,6 +56,10 @@ class WebpackReporter extends EventEmitter {
   }
 
   _stats(req, res) {
+    const jsonData = () => {
+      return this._reporterOptions.stats.toJson({}, true);
+    };
+
     res.format({
       json: () => {
         res.json(jsonData());


### PR DESCRIPTION
The `/reporter/stats` endpoint currently relies on a `jsonData` variable that isn't declared. Simply copied the declaration from the `_webReport` method over to it and seems to work fine.